### PR TITLE
allow specifying snapshot spec

### DIFF
--- a/pkg/snapshots/snapshots.go
+++ b/pkg/snapshots/snapshots.go
@@ -85,12 +85,10 @@ func createSnapshot(sg *v1.SnapshotGroup, annotations map[string]string) error {
 			Name:        sg.ObjectMeta.Name + "-" + timestamp,
 			Annotations: annotations,
 		},
-		Spec: snapshotsv1.VolumeSnapshotSpec{
-			Source: snapshotsv1.VolumeSnapshotSource{
-				PersistentVolumeClaimName: &sg.ObjectMeta.Name,
-			},
-		},
+		Spec: sg.Spec.Template.Spec,
 	}
+	snapshot.Spec.Source.PersistentVolumeClaimName = &sg.ObjectMeta.Name
+
 	marshaled, err := json.Marshal(snapshot)
 	if err != nil {
 		return err

--- a/pkg/types/snapshotgroup/v1/snapshotgroup.go
+++ b/pkg/types/snapshotgroup/v1/snapshotgroup.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	snapshotsv1 "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,11 +21,16 @@ type SnapshotGroup struct {
 
 type SnapshotGroupSpec struct {
 	Claim    SnapshotClaim      `json:"claim"`
+	Template SnapshotTemplate   `json:"template"`
 	Schedule []SnapshotSchedule `json:"schedule"`
 }
 
 type SnapshotClaim struct {
 	Spec corev1.PersistentVolumeClaimSpec `json:"spec"`
+}
+
+type SnapshotTemplate struct {
+	Spec snapshotsv1.VolumeSnapshotSpec `json:"spec"`
 }
 
 type SnapshotSchedule struct {


### PR DESCRIPTION
This change allows users to specify a VolumeSnapshotSpec to start all snapshots from. E.g.

```
spec:
  template:
    spec:
      volumeSnapshotClassName: csi-hostpath-snapclass
  claim:
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 2Gi
```