### PR TITLE
feat!: Add Kubernetes v1.22 support

### DIFF
--- a/pkg/kube/fake_client.go
+++ b/pkg/kube/fake_client.go
@@ -36,7 +36,7 @@ func SetFakeClient() *Client {
 }
 
 func createFakeClient() *Client {
-	objects := []k8sruntime.Object{}
+	var objects []k8sruntime.Object
 	k8s := k8sfake.NewSimpleClientset(objects...)
 	_ = snapshotsFake.NewSimpleClientset(objects...)
 

--- a/pkg/types/snapshotgroup/v1beta1/crd.go
+++ b/pkg/types/snapshotgroup/v1beta1/crd.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,65 +17,57 @@ import (
 
 // CreateCustomResourceDefinition creates the CRD and add it into Kubernetes. If there is error,
 // it will do some clean up.
-func CreateCustomResourceDefinition(namespace string, clientSet apiextensionsclientset.Interface) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      CRDName,
-			Namespace: namespace,
-		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   GroupName,
-			Version: SchemeGroupVersion.Version,
-			Scope:   apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural: Plural,
-				Kind:   reflect.TypeOf(SnapshotGroup{}).Name(),
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Type: "object",
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"spec": {
-							Type: "object",
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"persistentVolumeClaim": {
-									Type: "object",
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"claimName": {
-											Description: "PersistentVolumeClaim name to backup",
-											Type:        "string",
-										},
-										"spec": {
-											Description: "PersistentVolumeClaim spec to create and backup",
-											Type:        "object",
-										},
+func CreateCustomResourceDefinition(namespace string, clientSet apiextensionsclientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+	crdVersion := apiextensionsv1.CustomResourceDefinitionVersion{
+		Name:               GroupVersion,
+		Served:             true,
+		Storage:            true,
+		Deprecated:         false,
+		DeprecationWarning: nil,
+		Schema: &apiextensionsv1.CustomResourceValidation{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"spec": {
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"persistentVolumeClaim": {
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"claimName": {
+										Description: "PersistentVolumeClaim name to backup",
+										Type:        "string",
+									},
+									"spec": {
+										Description: "PersistentVolumeClaim spec to create and backup",
+										Type:        "object",
 									},
 								},
-								"schedule": {
-									Type: "array",
-									Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-										Schema: &apiextensionsv1beta1.JSONSchemaProps{
-											Type: "object",
-											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-												"every": {
-													Description: "Interval for creating new backups",
-													Type:        "string",
-												},
-												"keep": {
-													Description: "Number of historical backups to keep",
-													Type:        "integer",
-												},
+							},
+							"schedule": {
+								Type: "array",
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"every": {
+												Description: "Interval for creating new backups",
+												Type:        "string",
+											},
+											"keep": {
+												Description: "Number of historical backups to keep",
+												Type:        "integer",
 											},
 										},
 									},
 								},
-								"template": {
-									Type: "object",
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"spec": {
-											Description: "VolumeSnapshot spec",
-											Type:        "object",
-										},
+							},
+							"template": {
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"spec": {
+										Description: "VolumeSnapshot spec",
+										Type:        "object",
 									},
 								},
 							},
@@ -84,8 +76,28 @@ func CreateCustomResourceDefinition(namespace string, clientSet apiextensionscli
 				},
 			},
 		},
+		Subresources:             nil,
+		AdditionalPrinterColumns: nil,
 	}
-	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CRDName,
+			Namespace: namespace,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: GroupName,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: Plural,
+				Kind:   reflect.TypeOf(SnapshotGroup{}).Name(),
+			},
+			Scope:                 apiextensionsv1.NamespaceScoped,
+			Versions:              []apiextensionsv1.CustomResourceDefinitionVersion{crdVersion},
+			PreserveUnknownFields: false,
+		},
+	}
+
+	_, err := clientSet.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
 	if err == nil {
 		fmt.Println("CRD SnapshotGroup is created")
 	} else if apierrors.IsAlreadyExists(err) {
@@ -98,7 +110,7 @@ func CreateCustomResourceDefinition(namespace string, clientSet apiextensionscli
 
 	// Wait for CRD creation.
 	err = wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
-		crd, err = clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), CRDName, metav1.GetOptions{})
+		crd, err = clientSet.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), CRDName, metav1.GetOptions{})
 		if err != nil {
 			fmt.Printf("Fail to wait for CRD SnapshotGroup creation: %+v\n", err)
 
@@ -106,12 +118,12 @@ func CreateCustomResourceDefinition(namespace string, clientSet apiextensionscli
 		}
 		for _, cond := range crd.Status.Conditions {
 			switch cond.Type {
-			case apiextensionsv1beta1.Established:
-				if cond.Status == apiextensionsv1beta1.ConditionTrue {
+			case apiextensionsv1.Established:
+				if cond.Status == apiextensionsv1.ConditionTrue {
 					return true, err
 				}
-			case apiextensionsv1beta1.NamesAccepted:
-				if cond.Status == apiextensionsv1beta1.ConditionFalse {
+			case apiextensionsv1.NamesAccepted:
+				if cond.Status == apiextensionsv1.ConditionFalse {
 					fmt.Printf("Name conflict while wait for CRD SnapshotGroup creation: %s, %+v\n", cond.Reason, err)
 				}
 			}
@@ -123,7 +135,7 @@ func CreateCustomResourceDefinition(namespace string, clientSet apiextensionscli
 	// If there is an error, delete the object to keep it clean.
 	if err != nil {
 		fmt.Println("Try to cleanup")
-		deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), CRDName, metav1.DeleteOptions{})
+		deleteErr := clientSet.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), CRDName, metav1.DeleteOptions{})
 		if deleteErr != nil {
 			fmt.Printf("Fail to delete CRD SnapshotGroup: %+v\n", deleteErr)
 


### PR DESCRIPTION
This PR fixes #48 and fixes #52 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

This PR addresses API deprecation introduced in Kubernetes v1.22:

- `VolumeSnapshots` - use API `snapshot.storage.k8s.io/v1`
- `CustomResourceDifinition` - use API `apiextensions.k8s.io/v1`

### What changes did you make?

- `VolumeSnapshots` - `snapshot.storage.k8s.io/v1beta1` -> `snapshot.storage.k8s.io/v1`
- `CustomResourceDefinition` - `apiextensions.k8s.io/v1beta1` -> `apiextensions.k8s.io/v1`

### What alternative solution should we consider, if any?

N/A