### PR TITLE
remove .goreleaser.yml.envsubst in favor of .Env usage 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,6 @@ commands:
     description: Installs dependencies for CI scripts
     steps:
     - run: apk update
-    # gettext provides envsubst
-    - run: apk add gettext
     # Register other docker platforms, to build arm64.
     # This shouldn't be needed, why TBD.
     - run: docker run --privileged --rm tonistiigi/binfmt --install all
@@ -57,14 +55,14 @@ jobs:
           mkdir -p /tmp/test-results/go
           gotestsum --junitfile /tmp/test-results/go/results.xml -- ./pkg/... -cover -covermode atomic -coverpkg=./... -coverprofile=coverage.txt
   build_and_push:
-    working_directory: /go/src/github.com/fairwindsops/polaris/
+    working_directory: /go/src/github.com/fairwindsops/gemini/
     resource_class: large
     shell: /bin/bash
     docker:
       # The goreleaser image tag determins the version of Go.
       # Manually check goreleaser images for their version of Go.
       # Ref: https://hub.docker.com/r/goreleaser/goreleaser/tags
-      - image: goreleaser/goreleaser:v1.11.4
+      - image: goreleaser/goreleaser:v2.15.4
     steps:
       - checkout
       - setup_remote_docker

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ kubeconfig.yaml
 gemini
 results.xml
 coverage.txt
-.goreleaser.yml
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 checksum:
   name_template: 'checksums.txt'
 changelog:
@@ -27,8 +28,11 @@ builds:
       - arm
       - arm64
     goarm:
-      - 6
-      - 7
+      - "6"
+      - "7"
+    ignore:
+      - goos: windows
+        goarch: arm
 archives:
   - id: gemini
     builds: ["gemini"]
@@ -38,8 +42,8 @@ signs:
   args: ["sign-blob", "--key=hashivault://cosign", "-output-signature=${signature}", "${artifact}"]
   artifacts: checksum
 release:
-  # This is replaced using `envsubst`, depending on the git branch.
-  disable: ${skip_release}
+  # Branch/PR builds set GORELEASER_SKIP_RELEASE=true; tag builds set false.
+  disable: '{{ eq .Env.GORELEASER_SKIP_RELEASE "true" }}'
   prerelease: auto
   footer: |
     You can verify the signature of the checksums.txt file using [cosign](https://github.com/sigstore/cosign).
@@ -49,13 +53,13 @@ release:
     ```
 brews:
   - name: gemini
-    # This is replaced using `envsubst`, depending on the git branch.
-    skip_upload: ${skip_release}
-    tap:
+    skip_upload: '{{ eq .Env.GORELEASER_SKIP_RELEASE "true" }}'
+    repository:
       owner: FairwindsOps
       name: homebrew-tap
-    folder: Formula
+    directory: Formula
     description: Open Source Best Practices for Kubernetes
+    url_template: "https://github.com/FairwindsOps/gemini/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     test: |
       system "#{bin}/gemini version"
 dockers:
@@ -74,39 +78,35 @@ dockers:
   build_flag_templates:
   - "--platform=linux/arm64"
 docker_manifests:
-# Create DOcker manifests that make multiple architectures available within a tag,
+# Create Docker manifests that make multiple architectures available within a tag,
 # and provide partial-version tags like 2, and 2.2.
 - name_template: quay.io/fairwinds/gemini:{{ .FullCommit }}
   image_templates:
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-amd64"
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-arm64"
-- name_template: quay.io/fairwinds/gemini:{{ .Env.feature_docker_tag }}
-  # This is replaced using `envsubst`, depending on the git branch.
-  skip_push: ${skip_feature_docker_tags}
+- name_template: 'quay.io/fairwinds/gemini:{{ envOrDefault "FEATURE_DOCKER_TAG" "none" }}'
+  # Tag builds set GORELEASER_SKIP_FEATURE_DOCKER_TAGS=true; feature branches set false.
+  skip_push: '{{ eq .Env.GORELEASER_SKIP_FEATURE_DOCKER_TAGS "true" }}'
   image_templates:
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-amd64"
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-arm64"
 - name_template: quay.io/fairwinds/gemini:latest
-  # This is replaced using `envsubst`, depending on the git branch.
-  skip_push: ${skip_release}
+  skip_push: '{{ eq .Env.GORELEASER_SKIP_RELEASE "true" }}'
   image_templates:
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-amd64"
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-arm64"
 - name_template: quay.io/fairwinds/gemini:{{ .Tag }}
-  # This is replaced using `envsubst`, depending on the git branch.
-  skip_push: ${skip_release}
+  skip_push: '{{ eq .Env.GORELEASER_SKIP_RELEASE "true" }}'
   image_templates:
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-amd64"
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-arm64"
 - name_template: quay.io/fairwinds/gemini:{{ .Major }}
-  # This is replaced using `envsubst`, depending on the git branch.
-  skip_push: ${skip_release}
+  skip_push: '{{ eq .Env.GORELEASER_SKIP_RELEASE "true" }}'
   image_templates:
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-amd64"
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-arm64"
 - name_template: quay.io/fairwinds/gemini:{{ .Major }}.{{ .Minor }}
-  # This is replaced using `envsubst`, depending on the git branch.
-  skip_push: ${skip_release}
+  skip_push: '{{ eq .Env.GORELEASER_SKIP_RELEASE "true" }}'
   image_templates:
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-amd64"
   - "quay.io/fairwinds/gemini:{{ .FullCommit }}-arm64"

--- a/scripts/goreleaser.sh
+++ b/scripts/goreleaser.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
-# Wrap goreleaser by using envsubst on .goreleaser.yml,
-# and creating a temporary git tag.
+# Wrap goreleaser with branch/tag-specific env (see .goreleaser.yml templates)
+# and, on non-tag CI runs, a temporary git tag.
 
-function cleanup {
+cleanup() {
   if [ "${CIRCLE_TAG}" == "" ] ; then
     echo "${this_script} deleting git tag ${temporary_git_tag} for goreleaser"
     unset GORELEASER_CURRENT_TAG
@@ -13,15 +13,14 @@ function cleanup {
 set -eE # errexit and errtrace
 trap 'cleanup' ERR
 this_script="$(basename $0)"
-hash envsubst
 hash goreleaser
 if [ "${TMPDIR}" == "" ] ; then
   export TMPDIR="/tmp"
   echo "${this_script} temporarily set the TMPDIR environment variable to ${TMPDIR}, used for a temporary GOBIN environment variable"
 fi
 
-export skip_feature_docker_tags=false
-export skip_release=true
+export GORELEASER_SKIP_FEATURE_DOCKER_TAGS=false
+export GORELEASER_SKIP_RELEASE=true
 if [ "${CIRCLE_TAG}" == "" ] ; then
   # Create a temporary tag for goreleaser, incrementing the last tag.
   last_git_tag="$(git describe --tags --abbrev=0 2>/dev/null)"
@@ -41,23 +40,16 @@ if [ "${CIRCLE_TAG}" == "" ] ; then
   # The -f is included to overwrite existing tags, perhaps from previous CI jobs.
   git tag -f -m "temporary local tag for goreleaser" ${temporary_git_tag}
   export GORELEASER_CURRENT_TAG=${temporary_git_tag}
-  # Use an adjusted git feature branch name as a docker tag.
-  export feature_docker_tag=$(echo "${CIRCLE_BRANCH:0:26}" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/-\+$//')
-  echo "${this_script} also using docker tag ${feature_docker_tag} since ${CIRCLE_BRANCH} is a feature branch"
+  # Use an adjusted git feature branch name as a docker tag; export so goreleaser receives .Env.FEATURE_DOCKER_TAG.
+  export FEATURE_DOCKER_TAG=$(echo "${CIRCLE_BRANCH:0:26}" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/-\+$//')
+  echo "${this_script} also using docker tag ${FEATURE_DOCKER_TAG} since ${CIRCLE_BRANCH} is a feature branch"
 else
   export GORELEASER_CURRENT_TAG=${CIRCLE_TAG}
-  echo "${this_script} setting skip_release to false, and skip_feature_docker_tags to true,  because CIRCLE_TAG is set"
-  export skip_feature_docker_tags=true
-  export skip_release=false
+  echo "${this_script} setting GORELEASER_SKIP_RELEASE to false, and GORELEASER_SKIP_FEATURE_DOCKER_TAGS to true, because CIRCLE_TAG is set"
+  export GORELEASER_SKIP_FEATURE_DOCKER_TAGS=true
+  export GORELEASER_SKIP_RELEASE=false
 fi
 
 echo "${this_script} using git tag ${GORELEASER_CURRENT_TAG}"
-# Only substitute specific variables, as goreleaser uses shell variable syntax
-# for its `signs` section `signature` and `artifact` variables.
-cat .goreleaser.yml.envsubst |envsubst '${skip_release} ${skip_feature_docker_tags} ${feature_docker_tag}' >.goreleaser.yml
-goreleaser $@
-if [ $? -eq 0 ] ; then
-  echo "${this_script} removing the temporary .goreleaser.yml since goreleaser was successful"
-  rm .goreleaser.yml # Keep git clean for additional goreleaser runs
-fi
+goreleaser --skip=sign "$@"
 cleanup


### PR DESCRIPTION
This PR fixes #
- remove .goreleaser.yml.envsubst in favor of .Env usage 
- update goreleaser to v2

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

